### PR TITLE
Chocolatey Mod Recommended Changes & Housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+pulsar/tools/*.exe
+pulsar/*.nupkg

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ python init.py 1.103.0
 
 One must input the last version available on the website, otherwise the script will fail (it won't be able to download the installer).
 
-Once the script terminates, tha package is ready to be generated.
+Once the script terminates, the package is ready to be generated.
 
 ### Package generation
 
-Once the sources are updated, navigate to pulsar folder and run
+Once the sources are updated, navigate to `pulsar` folder and run:
+
+It is also recommended to update the following fields of the `pulsar.nuspec` prior to creating a new version:
+- `releaseNotes`
 
 ```
 choco pack
@@ -66,15 +69,19 @@ Test the package locally. From the command line shell, navigate to the directory
 choco install pulsar --source .
 ```
 
-Check that the commands executes without errors, and Pulsar gets instaled on your system.
+Check that the commands executes without errors, and Pulsar gets installed on your system.
 
-Try to unistall it, too
+Try to uninstall it, too
 
 ```
 choco uninstall pulsar
 ```
 
 If everything is ok, request to publish it on Chocolatey website.
+
+```
+choco push pulsar.1.103.0.nupkg --source https://push.chocolatey.org/
+```
 
 ## To do
 

--- a/pulsar/pulsar.nuspec
+++ b/pulsar/pulsar.nuspec
@@ -27,7 +27,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
     <version>1.103.0</version>
-    <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->
+    <packageSourceUrl>https://github.com/pulsar-edit/pulsar-chocolatey</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <!--<owners>__REPLACE_YOUR_NAME__</owners>-->
     <!-- ============================== -->
@@ -40,7 +40,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <projectUrl>https://pulsar-edit.dev</projectUrl>
     <!-- There are a number of CDN Services that can be used for hosting the Icon for a package. More information can be found here: https://docs.chocolatey.org/en-us/create/create-packages#package-icon-guidelines -->
     <!-- Here is an example using Githack -->
-    <iconUrl>https://cdn.statically.io/gh/il-mix/pulsar-chocolatey/main/resources/icon.png</iconUrl>
+    <iconUrl>https://cdn.statically.io/gh/pulsar-edit/pulsar-chocolatey/main/resources/icon.png</iconUrl>
     <copyright>Copyright (c) 2022-2023 Pulsar-Edit</copyright>
     <!-- If there is a license Url available, it is required for the community feed -->
     <licenseUrl>https://cdn.statically.io/gh/pulsar-edit/pulsar/03eace72/LICENSE.md</licenseUrl>
@@ -53,9 +53,8 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <summary>A Community-led Hyper-Hackable Text Editor</summary>
     <description>A Community-led Hyper-Hackable Text Editor, Forked from Atom, built on Electron.
 Designed to be deeply customizable, but still approachable using the default configuration.
-</description>
-    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
-    <!-- =============================== -->
+    </description>
+    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11030</releaseNotes>
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <!--<dependencies>


### PR DESCRIPTION
In this PR I've addressed some issues the automated Chocolatey validator suggested. Namely adding `releaseNotes` and `packageSourceUrl`.

Those changes have already been pushed to our pending chocolatey package.

Additionally, I've updated some of the fields here to point to our repos rather than the original creator. 

But otherwise this PR does some light housekeeping on the repo, such as beefing up the readme and removing spelling issues, and adds a `.gitignore` file, so that maintainers can build the packages to be distributed, and have them properly ignored in the repo.