### PR TITLE
Version `1.104.0`

### DIFF
--- a/init.py
+++ b/init.py
@@ -15,52 +15,52 @@ class PackageFilesEditor():
 	INSTALL_SCRIPT_PATH = PACKAGE_SOURCES_PATH + "tools/chocolateyinstall.ps1"
 	INSTALLER_PATH = PACKAGE_SOURCES_PATH + "tools/"
 	VERIFICATION_FILE_PATH = INSTALLER_PATH + "VERIFICATION.txt"
-	
+
 	# Class properties
 	pulsarVersion_ = 0
 	installerUrl_ = "https://github.com/pulsar-edit/pulsar/releases/download/"
 	installerFileName_ = ""
 	installerChecksum_ = ""
-	
+
 	# Class initializer
 	def __init__(self, pulsarVersion):
 		self.pulsarVersion_ = pulsarVersion
 		self.installerFileName_ = "Windows.Pulsar.Setup." + pulsarVersion + ".exe"
 		self.installerUrl_ = self.installerUrl_ + "v" + pulsarVersion + "/" + self.installerFileName_
-	
+
 	# Main function run from main
 	def run(self):
 		print("Init configuration files to generate package for version " + self.pulsarVersion_)
-		
+
 		self.downloadInstaller()
-		
+
 		self.editNuspecPackage()
 		self.editInstallScript()
 		self.generateVerificationFile()
-		
+
 		print("Package sources initialized")
-		
-	
+
+
 	def downloadInstaller(self):
 		print("Download installer for version " + self.pulsarVersion_ + "...")
-		
+
 		response = requests.get(self.installerUrl_)
 		if(response.status_code != 200):
 			print("Error " + str(response.status_code) + " while downloading install file")
 			sys.exit(1)
-		
+
 		open(self.INSTALLER_PATH + self.installerFileName_, "wb").write(response.content)
-		
+
 		print("DONE")
-		
+
 		print("Compute SHA256 checksum...")
-		
+
 		with open(self.INSTALLER_PATH + self.installerFileName_, "rb") as f:
 			bytes = f.read() # read entire file as bytes
 			self.installerChecksum_ = hashlib.sha256(bytes).hexdigest();
-			
+
 		print("DONE")
-	
+
 	def editNuspecPackage(self):
 		print("Edit " + self.NUSPEC_FILE + "file...")
 		nuspecFileOriginal = codecs.open(self.NUSPEC_FILE, "r", "utf-8")
@@ -68,16 +68,18 @@ class PackageFilesEditor():
 		for line in nuspecFileOriginal:
 			if "<version>" in line:
 				nuspecFileNew.write("    <version>" + self.pulsarVersion_ + "</version>" + os.linesep)
+			if "<releaseNotes>" in line:
+				nuspecFileNew.write("	<releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#" + re.sub(r'[^\w\s]', '', self.pulsarVersion_) + "</releaseNotes>" + os.linesep)
 			else:
 				nuspecFileNew.write(line)
 		nuspecFileOriginal.close()
 		nuspecFileNew.close()
-		
+
 		shutil.copy2("tmp", self.NUSPEC_FILE)
 		os.remove("tmp")
-		
+
 		print("DONE")
-		
+
 	def editInstallScript(self):
 		print("Edit " + self.INSTALL_SCRIPT_PATH + "file...")
 		installScriptOriginal = codecs.open(self.INSTALL_SCRIPT_PATH, "r", "utf-8")
@@ -91,37 +93,36 @@ class PackageFilesEditor():
 				installScriptNew.write(line)
 		installScriptOriginal.close()
 		installScriptNew.close()
-		
+
 		shutil.copy2("tmp", self.INSTALL_SCRIPT_PATH)
 		os.remove("tmp")
-		
+
 		print("DONE")
-		
+
 	def generateVerificationFile(self):
 		print("Generate verification file...");
 		verificationFile = codecs.open(self.VERIFICATION_FILE_PATH, "w", "utf-8")
-		
+
 		verificationFile.write("VERIFICATION" + os.linesep)
 		verificationFile.write(os.linesep)
 		verificationFile.write("Installer file: " + self.installerFileName_ + os.linesep)
 		verificationFile.write("Checksum: " + self.installerChecksum_ + os.linesep)
 		verificationFile.write("Checksum type: SHA256" + os.linesep)
 		verificationFile.write("Original installer and checksums can be found at: https://github.com/pulsar-edit/pulsar/releases/tag/v" + self.pulsarVersion_ + os.linesep)
-		
+
 		verificationFile.close()
-		
+
 		print("DONE")
-	
+
 # Main function
 if __name__ == '__main__':
 	# Command line arguments parsing
 	parser = argparse.ArgumentParser(description="Init Chocolatey Pulsar package configuration files", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 	parser.add_argument("version", help="Pulsar version")
 	args = parser.parse_args()
-	
+
 	# Run files edit
 	packageFilesEditor = PackageFilesEditor(args.version)
 	packageFilesEditor.run()
-	
+
 	print("Navigate to pulsar folder and generate package with 'choco pack' command")
-		

--- a/pulsar/pulsar.nuspec
+++ b/pulsar/pulsar.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.103.0</version>
+    <version>1.104.0</version>
     <packageSourceUrl>https://github.com/pulsar-edit/pulsar-chocolatey</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <!--<owners>__REPLACE_YOUR_NAME__</owners>-->
@@ -54,7 +54,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <description>A Community-led Hyper-Hackable Text Editor, Forked from Atom, built on Electron.
 Designed to be deeply customizable, but still approachable using the default configuration.
     </description>
-    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11030</releaseNotes>
+	<releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11040</releaseNotes>
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <!--<dependencies>

--- a/pulsar/tools/VERIFICATION.txt
+++ b/pulsar/tools/VERIFICATION.txt
@@ -1,6 +1,6 @@
 VERIFICATION
 
-Installer file: Windows.Pulsar.Setup.1.103.0.exe
-Checksum: e63c7c33c1d98762331ce3964eaf208bd868ae20f0642d119fe9e257eafb9e72
+Installer file: Windows.Pulsar.Setup.1.104.0.exe
+Checksum: 253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7
 Checksum type: SHA256
-Original installer and checksums can be found at: https://github.com/pulsar-edit/pulsar/releases/tag/v1.103.0
+Original installer and checksums can be found at: https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0

--- a/pulsar/tools/chocolateyinstall.ps1
+++ b/pulsar/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$fileLocation = Join-Path $toolsDir 'Windows.Pulsar.Setup.1.103.0.exe'
+$fileLocation = Join-Path $toolsDir 'Windows.Pulsar.Setup.1.104.0.exe'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -9,7 +9,7 @@ $packageArgs = @{
   fileType       = 'exe'
   file           = $fileLocation
   softwareName   = 'Pulsar'
-  checksum       = 'e63c7c33c1d98762331ce3964eaf208bd868ae20f0642d119fe9e257eafb9e72'
+  checksum       = '253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7'
   checksumType   = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0)


### PR DESCRIPTION
So here I tried to update the Pulsar Chocolatey package to the newest version.

But unfortunately we can't yet.

I thought it'd be good to include this PR as both a way of defining that this has been attempted, and to document the issue at hand for anyone wondering why Chocolatey isn't up to date.

---

Essentially, the Pulsar binary installer has increased in size considerably. This is because on Windows we had been failing to build `fuzzy-finder` correctly for some time. Which now that it builds correctly `vscode-ripgrep` is actually taking up a considerable amount of additional space.

Currently Pulsar `1.104.0` `pulsar.1.104.0.nupkg` is `222MB` but the max size it can be to be published is `200MB`. So we have a few options:

* Find a way to defer downloading of the Pulsar binary until a user actually installs it
* Reduce the Pulsar binary size

Since I'm not the most familiar with Chocolatey, and those that had originally set up this repo haven't been present since publication, I'll pursue getting the Pulsar binary smaller. If anyone else wants to take a shot at changing the way Chocolatey installs Pulsar, by all means, please do so, and if you do just make sure to take the changes on this PR to `init.py`.

Otherwise hopefully, once the binary size is reduced, this PR can be accepted but publishing a specific rolling release version of Pulsar instead, just so we can get something on `1.104.x` out on Chocolatey 