### PR TITLE
Edits to init.py and package to let the install script download the setup file

### DIFF
--- a/init.py
+++ b/init.py
@@ -46,7 +46,7 @@ class PackageFilesEditor():
 		self.retirieveInstallerChecksum()
 		
 		self.editNuspecPackage()
-		#self.editInstallScript()
+		self.editInstallScript()
 		self.generateVerificationFile()
 		
 		print("Package sources initialized")
@@ -77,7 +77,7 @@ class PackageFilesEditor():
 		print("DONE")
 	
 	def editNuspecPackage(self):
-		print("Edit " + self.NUSPEC_FILE + "file...")
+		print("Edit " + self.NUSPEC_FILE + " file...")
 		nuspecFileOriginal = codecs.open(self.NUSPEC_FILE, "r", "utf-8")
 		nuspecFileNew = codecs.open("tmp", "w", "utf-8")
 		for line in nuspecFileOriginal:
@@ -96,12 +96,12 @@ class PackageFilesEditor():
 		print("DONE")
 		
 	def editInstallScript(self):
-		print("Edit " + self.INSTALL_SCRIPT_PATH + "file...")
+		print("Edit " + self.INSTALL_SCRIPT_PATH + " file...")
 		installScriptOriginal = codecs.open(self.INSTALL_SCRIPT_PATH, "r", "utf-8")
 		installScriptNew = codecs.open("tmp", "w", "utf-8")
 		for line in installScriptOriginal:
-			if ".exe" in line:
-				installScriptNew.write("$fileLocation = Join-Path $toolsDir '" + self.installerFileName_ + "'" + os.linesep)
+			if "https" in line:
+				installScriptNew.write("$url = '" + self.installerDownloadUrl_ + "'" + os.linesep)
 			elif "checksum" in line and not "Type" in line:
 				installScriptNew.write("  checksum       = '" + self.installerChecksum_ + "'" + os.linesep)
 			else:

--- a/init.py
+++ b/init.py
@@ -13,9 +13,12 @@ class PackageFilesEditor():
 	PACKAGE_SOURCES_PATH = "./pulsar/"
 	NUSPEC_FILE = PACKAGE_SOURCES_PATH + "pulsar.nuspec"
 	INSTALL_SCRIPT_PATH = PACKAGE_SOURCES_PATH + "tools/chocolateyinstall.ps1"
-	INSTALLER_PATH = PACKAGE_SOURCES_PATH + "tools/"
-	VERIFICATION_FILE_PATH = INSTALLER_PATH + "VERIFICATION.txt"
+	TOOLS_PATH = PACKAGE_SOURCES_PATH + "tools/"
+	VERIFICATION_FILE_PATH = TOOLS_PATH + "VERIFICATION.txt"
 	INSTALLER_CHECKSUM_FILE_NAME = "SHA256SUMS.txt"
+	LICENSE_URL = "https://github.com/pulsar-edit/pulsar/blob/master/LICENSE.md"
+	LICENSE_URL_RAW = "https://raw.githubusercontent.com/pulsar-edit/pulsar/master/LICENSE.md"
+	LICENSE_FILE_PATH = TOOLS_PATH + "LICENSE.txt"
 	
 	# Class properties
 	pulsarVersion_ = ""
@@ -48,6 +51,7 @@ class PackageFilesEditor():
 		self.editNuspecPackage()
 		self.editInstallScript()
 		self.generateVerificationFile()
+		self.downloadLicenseFile()
 		
 		print("Package sources initialized")
 	
@@ -85,6 +89,8 @@ class PackageFilesEditor():
 				nuspecFileNew.write("    <version>" + self.pulsarVersion_ + "</version>" + os.linesep)
 			elif "<releaseNotes>" in line:
 				nuspecFileNew.write("    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#" + self.pulsarVersion_.replace(".","") + "</releaseNotes>" + os.linesep)
+			elif "<licenseUrl>" in line:
+				nuspecFileNew.write("    <licenseUrl>" + self.LICENSE_URL + "</licenseUrl>" + os.linesep)
 			else:
 				nuspecFileNew.write(line)
 		nuspecFileOriginal.close()
@@ -115,7 +121,7 @@ class PackageFilesEditor():
 		print("DONE")
 		
 	def generateVerificationFile(self):
-		print("Generate verification file...");
+		print("Generate verification file...")
 		verificationFile = codecs.open(self.VERIFICATION_FILE_PATH, "w", "utf-8")
 		
 		verificationFile.write("VERIFICATION" + os.linesep)
@@ -125,6 +131,18 @@ class PackageFilesEditor():
 		verificationFile.write("Checksum will be checked automatically by installer script." + os.linesep)
 		
 		verificationFile.close()
+		
+		print("DONE")
+		
+	def downloadLicenseFile(self):
+		print("Download license file...")
+		
+		response = requests.get(self.LICENSE_URL_RAW)
+		if(response.status_code != 200):
+			print("Error " + str(response.status_code) + " while downloading license file")
+			sys.exit(1)
+		
+		open(self.LICENSE_FILE_PATH, "wb").write(response.content)
 		
 		print("DONE")
 	

--- a/init.py
+++ b/init.py
@@ -20,6 +20,7 @@ class PackageFilesEditor():
 	# Class properties
 	pulsarVersion_ = ""
 	pulsarVersionName_ = ""
+	githubReleaseUrl_ = "https://github.com/pulsar-edit/pulsar/releases/tag/"
 	assetsDownloadUrl_ = "https://github.com/pulsar-edit/pulsar/releases/download/"
 	installerFileName_ = "Windows.Pulsar.Setup"
 	installerDownloadUrl_ = ""
@@ -33,6 +34,7 @@ class PackageFilesEditor():
 			self.pulsarVersion_ = self.pulsarVersion_[1:]
 		self.pulsarVersionName_ = "v" + self.pulsarVersion_
 		self.installerFileName_ = "Windows.Pulsar.Setup." + self.pulsarVersion_ + ".exe"
+		self.githubReleaseUrl_ = self.githubReleaseUrl_ + self.pulsarVersionName_
 		self.assetsDownloadUrl_ = self.assetsDownloadUrl_ + self.pulsarVersionName_
 		self.installerDownloadUrl_ = self.assetsDownloadUrl_ + "/" + self.installerFileName_
 		self.installerChecksumDownloadUrl_ = self.assetsDownloadUrl_ + "/" + self.INSTALLER_CHECKSUM_FILE_NAME	
@@ -45,7 +47,7 @@ class PackageFilesEditor():
 		
 		self.editNuspecPackage()
 		#self.editInstallScript()
-		#self.generateVerificationFile()
+		self.generateVerificationFile()
 		
 		print("Package sources initialized")
 	
@@ -118,10 +120,9 @@ class PackageFilesEditor():
 		
 		verificationFile.write("VERIFICATION" + os.linesep)
 		verificationFile.write(os.linesep)
-		verificationFile.write("Installer file: " + self.installerFileName_ + os.linesep)
-		verificationFile.write("Checksum: " + self.installerChecksum_ + os.linesep)
-		verificationFile.write("Checksum type: SHA256" + os.linesep)
-		verificationFile.write("Original installer and checksums can be found at: https://github.com/pulsar-edit/pulsar/releases/tag/v" + self.pulsarVersion_ + os.linesep)
+		verificationFile.write("Install script will download " + self.installerFileName_ + " from " + self.githubReleaseUrl_ + os.linesep)
+		verificationFile.write("Installer checksum (SHA256): " + self.installerChecksum_ + os.linesep)
+		verificationFile.write("Checksum will be checked automatically by installer script." + os.linesep)
 		
 		verificationFile.close()
 		

--- a/init.py
+++ b/init.py
@@ -31,7 +31,7 @@ class PackageFilesEditor():
 		self.pulsarVersion_ = pulsarVersion
 		if(self.pulsarVersion_[0] == "v"):
 			self.pulsarVersion_ = self.pulsarVersion_[1:]
-		self.pulsarVersionName_ = "v" + pulsarVersion
+		self.pulsarVersionName_ = "v" + self.pulsarVersion_
 		self.installerFileName_ = "Windows.Pulsar.Setup." + self.pulsarVersion_ + ".exe"
 		self.assetsDownloadUrl_ = self.assetsDownloadUrl_ + self.pulsarVersionName_
 		self.installerDownloadUrl_ = self.assetsDownloadUrl_ + "/" + self.installerFileName_

--- a/init.py
+++ b/init.py
@@ -29,9 +29,9 @@ class PackageFilesEditor():
 	def __init__(self, pulsarVersion):
 		# Initialize file names and URLs given required version
 		self.pulsarVersion_ = pulsarVersion
-		self.pulsarVersionName_ = pulsarVersion
-		if(self.pulsarVersionName_[0] != "v"):
-			self.pulsarVersionName_ = "v" + self.pulsarVersionName_
+		if(self.pulsarVersion_[0] == "v"):
+			self.pulsarVersion_ = self.pulsarVersion_[1:]
+		self.pulsarVersionName_ = "v" + pulsarVersion
 		self.installerFileName_ = "Windows.Pulsar.Setup." + self.pulsarVersion_ + ".exe"
 		self.assetsDownloadUrl_ = self.assetsDownloadUrl_ + self.pulsarVersionName_
 		self.installerDownloadUrl_ = self.assetsDownloadUrl_ + "/" + self.installerFileName_
@@ -43,7 +43,7 @@ class PackageFilesEditor():
 		
 		self.retirieveInstallerChecksum()
 		
-		#self.editNuspecPackage()
+		self.editNuspecPackage()
 		#self.editInstallScript()
 		#self.generateVerificationFile()
 		
@@ -81,6 +81,8 @@ class PackageFilesEditor():
 		for line in nuspecFileOriginal:
 			if "<version>" in line:
 				nuspecFileNew.write("    <version>" + self.pulsarVersion_ + "</version>" + os.linesep)
+			elif "<releaseNotes>" in line:
+				nuspecFileNew.write("    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#" + self.pulsarVersion_.replace(".","") + "</releaseNotes>" + os.linesep)
 			else:
 				nuspecFileNew.write(line)
 		nuspecFileOriginal.close()

--- a/pulsar/pulsar.nuspec
+++ b/pulsar/pulsar.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.103.0</version>
+    <version>1.104.0</version>
     <packageSourceUrl>https://github.com/pulsar-edit/pulsar-chocolatey</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <!--<owners>__REPLACE_YOUR_NAME__</owners>-->
@@ -43,7 +43,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <iconUrl>https://cdn.statically.io/gh/pulsar-edit/pulsar-chocolatey/main/resources/icon.png</iconUrl>
     <copyright>Copyright (c) 2022-2023 Pulsar-Edit</copyright>
     <!-- If there is a license Url available, it is required for the community feed -->
-    <licenseUrl>https://cdn.statically.io/gh/pulsar-edit/pulsar/03eace72/LICENSE.md</licenseUrl>
+    <licenseUrl>https://github.com/pulsar-edit/pulsar/blob/master/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/pulsar-edit/pulsar</projectSourceUrl>
     <docsUrl>https://pulsar-edit.dev/docs/</docsUrl>
@@ -54,7 +54,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <description>A Community-led Hyper-Hackable Text Editor, Forked from Atom, built on Electron.
 Designed to be deeply customizable, but still approachable using the default configuration.
     </description>
-    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11030</releaseNotes>
+    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11040</releaseNotes>
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <!--<dependencies>

--- a/pulsar/tools/LICENSE.txt
+++ b/pulsar/tools/LICENSE.txt
@@ -1,11 +1,22 @@
-﻿From: https://cdn.statically.io/gh/pulsar-edit/pulsar/03eace72/LICENSE.md
-
 MIT License
 
-Copyright (c) 2022-2023 Pulsar-Edit Original work copyright (c) 2011-2022 GitHub Inc.
+Copyright (c) 2022-2023 Pulsar-Edit
+Original work copyright (c) 2011-2022 GitHub Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pulsar/tools/VERIFICATION.txt
+++ b/pulsar/tools/VERIFICATION.txt
@@ -1,6 +1,5 @@
 VERIFICATION
 
-Installer file: Windows.Pulsar.Setup.1.103.0.exe
-Checksum: e63c7c33c1d98762331ce3964eaf208bd868ae20f0642d119fe9e257eafb9e72
-Checksum type: SHA256
-Original installer and checksums can be found at: https://github.com/pulsar-edit/pulsar/releases/tag/v1.103.0
+Install script will download Windows.Pulsar.Setup.1.104.0.exe from https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0
+Installer checksum (SHA256): 253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7
+Checksum will be checked automatically by installer script.

--- a/pulsar/tools/chocolateyinstall.ps1
+++ b/pulsar/tools/chocolateyinstall.ps1
@@ -1,18 +1,16 @@
-﻿
-$ErrorActionPreference = 'Stop'
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$fileLocation = Join-Path $toolsDir 'Windows.Pulsar.Setup.1.103.0.exe'
+﻿$ErrorActionPreference = 'Stop'
+$url = 'https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Windows.Pulsar.Setup.1.104.0.exe'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   unzipLocation  = $toolsDir
   fileType       = 'exe'
-  file           = $fileLocation
+  url            = $url
   softwareName   = 'Pulsar'
-  checksum       = 'e63c7c33c1d98762331ce3964eaf208bd868ae20f0642d119fe9e257eafb9e72'
+  checksum       = '253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7'
   checksumType   = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0)
 }
 
-Install-ChocolateyInstallPackage @packageArgs
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
To avoid package size limitations, instead of embedding the installer in the package, the init.py script will edit the package's source files so that the setup file will be installed during Chocolatey package installation.