### PR TITLE
[1.105.0] Release

### DIFF
--- a/pulsar/pulsar.nuspec
+++ b/pulsar/pulsar.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.104.0</version>
+    <version>1.105.0</version>
     <packageSourceUrl>https://github.com/pulsar-edit/pulsar-chocolatey</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <!--<owners>__REPLACE_YOUR_NAME__</owners>-->
@@ -54,7 +54,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <description>A Community-led Hyper-Hackable Text Editor, Forked from Atom, built on Electron.
 Designed to be deeply customizable, but still approachable using the default configuration.
     </description>
-    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11040</releaseNotes>
+    <releaseNotes>https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#11050</releaseNotes>
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <!--<dependencies>

--- a/pulsar/tools/VERIFICATION.txt
+++ b/pulsar/tools/VERIFICATION.txt
@@ -1,5 +1,5 @@
 VERIFICATION
 
-Install script will download Windows.Pulsar.Setup.1.104.0.exe from https://github.com/pulsar-edit/pulsar/releases/tag/v1.104.0
-Installer checksum (SHA256): 253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7
+Install script will download Windows.Pulsar.Setup.1.105.0.exe from https://github.com/pulsar-edit/pulsar/releases/tag/v1.105.0
+Installer checksum (SHA256): bff670f75f52da3b8c712bb9d51d0487e879cb00297afbcef621748579cc50b4
 Checksum will be checked automatically by installer script.

--- a/pulsar/tools/chocolateyinstall.ps1
+++ b/pulsar/tools/chocolateyinstall.ps1
@@ -1,5 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop'
-$url = 'https://github.com/pulsar-edit/pulsar/releases/download/v1.104.0/Windows.Pulsar.Setup.1.104.0.exe'
+$url = 'https://github.com/pulsar-edit/pulsar/releases/download/v1.105.0/Windows.Pulsar.Setup.1.105.0.exe'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -7,7 +7,7 @@ $packageArgs = @{
   fileType       = 'exe'
   url            = $url
   softwareName   = 'Pulsar'
-  checksum       = '253449889bdeb5c6b48ed7deb8e6b4e853da1624b06fe2a53c0663e508392ab7'
+  checksum       = 'bff670f75f52da3b8c712bb9d51d0487e879cb00297afbcef621748579cc50b4'
   checksumType   = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0)


### PR DESCRIPTION
Because of my own blunder when drafting this release for Pulsar, the `SHA256SUMS.txt` file was encoded in UTF-16LE with BOM.

This meant the easiest answer was the manually edit the aspects for this release, and run `choco pack` from there, instead of using the script to update it.

But this release is now drafted and awaiting moderation from the chocolatey team.