### PR TITLE
GitHub Action to test installation of Pulsar via chocolatey

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,5 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "$(pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY
+      #run: echo "$(pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "Pulsar : 1.104.0\nElectron: 12.2.3\nChrome: 89.0.4389.128\nNode: 14.16.0" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,22 +20,15 @@ jobs:
 
     - name: Put Pulsar On the PATH
       run: |
-        "$env:LOCALAPPDATA\Programs\Pulsar\" | Out-File -Append -FilePath $env:GITHUB_PATH
-        "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" | Out-File -Append -FilePath $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        $version = pulsar --version |
-        ConvertFrom-String -PropertyNames Application, Delimiter, Version |
-        Where-Object { $PSItem.Application -eq "Pulsar" } |
-        Select-Object -ExpandProperty version
-        Write-Host "pulsarVersion=`"$($version)`"" | Out-File -Append -FilePath $env:GITHUB_ENV
-
-    - name: Just a check
-      run: echo '${{ env.pulsarVersion }}'
-
-    - name: Write Comment
-      uses: thollander/actions-comment-pull-request@v2
-      with:
-        message: "Pulsar Version: ${{ env.pulsarVersion }}"
+        (
+        pulsar --version |
+        ConvertFrom-String -PropertyNames Application,Delimiter,Version |
+        Where-Object {$_.Application -eq "Pulsar" } |
+        Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
+        ).version >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "$(pulsar --version)" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$(pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,4 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ $PulsarVersion }}
+          ${{ github.env.PulsarVersion }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Chocolatey Test Installation
+
+on: [ workflow_dispatch, pull_request]
+
+jobs:
+  tests:
+    runs-on: windows-latest
+
+    steps:
+    - name: Build Current Version
+      run: |
+      cd ./pulsar
+      choco pack
+
+    - name: Install Current Version
+      run: choco install pulsar --source .
+
+    - name: Put Pulsar On the PATH
+      run: |
+      "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
+      "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
+
+    - name: Ensure Installation was successful
+      run: pulsar --version >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version | Write-Host >> $env:GITHUB_STEP_SUMMARY
+      run: pulsar --version | Write-Host >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: ${{ steps.pulsar-version.outputs }}
+        message: |
+          ${{ steps.pulsar-version.outputs }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: Write-Host "## Hello World :rocket:" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "## Hello World :rocket:" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version) >> $GITHUB_OUTPUT
+        ).version >> $GITHUB_OUTPUT
 
     - name: Just a check
       run: echo "${{ steps.pulsar-version.outputs }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,18 +26,17 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        (
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version >> $env:PulsarVersion
+        ).version >> $env:GITHUB_STEP_SUMMARY
 
     - name: Just a check
-      run: echo $env:PulsarVersion
+      run: echo $env:GITHUB_STEP_SUMMARY
 
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ github.env.PulsarVersion }}
+          ${{ github.env.GITHUB_STEP_SUMMARY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "$((pulsar --version))" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$((pulsar --version | Write-Host))" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,15 +20,23 @@ jobs:
 
     - name: Put Pulsar On the PATH
       run: |
-        "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
-        "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\" | Out-File -Append -FilePath $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" | Out-File -Append -FilePath $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        (
-        pulsar --version |
-        ConvertFrom-String -PropertyNames Application,Delimiter,Version |
-        Where-Object {$_.Application -eq "Pulsar" } |
+        $version = (pulsar --version |
+        ConvertFrom-String -PropertyNames Application, Delimiter, Version |
+        Where-Object {$PSItem.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version >> $env:GITHUB_STEP_SUMMARY
+        ).version
+        Write-Host "pulsarVersion=$($version)" | Out-File -Append -FilePath $env:GITHUB_ENV
+
+    - name: Just a check
+      run: echo '${{ env.pulsarVersion }}'
+
+    - name: Write Comment
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: ${{ env.pulsarVersion }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         ConvertFrom-String -PropertyNames Application, Delimiter, Version |
         Where-Object { $PSItem.Application -eq "Pulsar" } |
         Select-Object -ExpandProperty version
-        Write-Host "pulsarVersion='$($version)'" | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host "pulsarVersion=`"$($version)`"" | Out-File -Append -FilePath $env:GITHUB_ENV
 
     - name: Just a check
       run: echo '${{ env.pulsarVersion }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,7 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version | ConvertFrom-String -PropertyNames Application,Delimiter,Version | Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY
+      run: |
+        pulsar --version |
+        ConvertFrom-String -PropertyNames Application,Delimiter,Version |
+        Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "$((pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$((pulsar --version | Write-Host))" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Can we set the Step Summary Successfully?
       #run: echo "$(pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY
-      run: echo "Pulsar : 1.104.0\nElectron: 12.2.3\nChrome: 89.0.4389.128\nNode: 14.16.0" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "Pulsar : 1.104.0\\nElectron: 12.2.3\\nChrome: 89.0.4389.128\\nNode: 14.16.0" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ $PulsarVersion}}
+          ${{ github.env.PulsarVersion }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,12 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        (
+        version=$((
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version >> $GITHUB_OUTPUT
+        ).version) >> $GITHUB_OUTPUT
 
     - name: Just a check
       run: echo "${{ steps.pulsar-version.outputs }}"
@@ -40,4 +40,4 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ steps.pulsar-version.outputs }}
+          ${{ steps.pulsar-version.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,5 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      #run: echo "$(pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY
-      run: echo "Pulsar : 1.104.0\\nElectron: 12.2.3\\nChrome: 89.0.4389.128\\nNode: 14.16.0" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$((pulsar --version | Write-Host)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v3
-      
+
     - name: Build Current Version
       run: |
         cd ./pulsar
@@ -24,4 +24,4 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version >> $GITHUB_STEP_SUMMARY
+      run: pulsar --version >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "## Hello World :rocket:" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$(pulsar --version)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,11 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        $version = (pulsar --version |
+        $version = pulsar --version |
         ConvertFrom-String -PropertyNames Application, Delimiter, Version |
-        Where-Object {$PSItem.Application -eq "Pulsar" } |
-        Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version
-        Write-Host "pulsarVersion='$($version)'" | Out-File -Append -FilePath $env:GITHUB_ENV
+        Where-Object { $PSItem.Application -eq "Pulsar" } |
+        Select-Object -ExpandProperty version
+        Write-Host "pulsarVersion=$($version)" | Out-File -Append -FilePath $env:GITHUB_ENV
 
     - name: Just a check
       run: echo '${{ env.pulsarVersion }}'
@@ -39,4 +38,4 @@ jobs:
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: ${{ env.pulsarVersion }}
+        message: "Pulsar Version: ${{ env.pulsarVersion }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,18 +26,17 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        $version=(
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version >> $GITHUB_OUTPUT
+        ).version >> $env:PulsarVersion
 
     - name: Just a check
-      run: echo "${{ steps.pulsar-version.outputs }}"
+      run: echo $env:PulsarVersion
 
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ steps.pulsar-version.outputs.version }}
+          ${{ $PulsarVersion }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,16 +9,16 @@ jobs:
     steps:
     - name: Build Current Version
       run: |
-      cd .\pulsar
-      choco pack
+        cd ./pulsar
+        choco pack
 
     - name: Install Current Version
       run: choco install pulsar --source .
 
     - name: Put Pulsar On the PATH
       run: |
-      "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
-      "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
       run: pulsar --version >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       shell: pwsh
 
     - name: Can we set the Step Summary Successfully?
-      run: echo "$((pulsar --version | Write-Host))" >> $env:GITHUB_STEP_SUMMARY
+      run: echo "$((pulsar --version))" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         Where-Object {$PSItem.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
         ).version
-        Write-Host "pulsarVersion=$($version)" | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host "pulsarVersion='$($version)'" | Out-File -Append -FilePath $env:GITHUB_ENV
 
     - name: Just a check
       run: echo '${{ env.pulsarVersion }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,18 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
+        (
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
-        Where-Object {$_.Application -eq "Pulsar" } >> $env:PulsarVersion
+        Where-Object {$_.Application -eq "Pulsar" } |
+        Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
+        ).version >> $GITHUB_OUTPUT
+
+    - name: Just a check
+      run: echo "${{ steps.pulsar-version.outputs }}"
 
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ github.env.PulsarVersion }}
+          ${{ steps.pulsar-version.outputs }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,4 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version | Write-Host >> $env:GITHUB_STEP_SUMMARY
-      shell: pwsh
-
-    - name: Can we set the Step Summary Successfully?
-      run: echo "$((pulsar --version | Write-Host))" >> $env:GITHUB_STEP_SUMMARY
-
-    - name: What is possibly the value of GITHUB_STEP_SUMMARY?
-      run: echo $env:GITHUB_STEP_SUMMARY
+      run: pulsar --version | ConvertFrom-String -PropertyNames Application,Delimiter,Version | Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,5 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version | Write-Host >> $GITHUB_STEP_SUMMARY
+      run: pulsar --version | Write-Host >> $env:GITHUB_STEP_SUMMARY
+      shell: pwsh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,3 +26,6 @@ jobs:
     - name: Ensure Installation was successful
       run: pulsar --version | Write-Host >> $env:GITHUB_STEP_SUMMARY
       shell: pwsh
+
+    - name: Can we set the Step Summary Successfully?
+      run: Write-Host "## Hello World :rocket:" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,6 @@ jobs:
         Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY
 
     - name: Write Comment
-      uses: thollander/actions-comment-pull-reqest@v2
+      uses: thollander/actions-comment-pull-request@v2
       with:
         message: $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
-      run: pulsar --version >> $env:GITHUB_STEP_SUMMARY
+      run: pulsar --version | Write-Host >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,3 @@ jobs:
         Where-Object {$_.Application -eq "Pulsar" } |
         Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
         ).version >> $env:GITHUB_STEP_SUMMARY
-
-    - name: Just a check
-      run: echo $env:GITHUB_STEP_SUMMARY
-
-    - name: Write Comment
-      uses: thollander/actions-comment-pull-request@v2
-      with:
-        message: |
-          ${{ github.env.GITHUB_STEP_SUMMARY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,8 @@ jobs:
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY
+
+    - name: Write Comment
+      uses: thollander/actions-comment-pull-reqest@v2
+      with:
+        message: $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - name: Build Current Version
       run: |
-      cd ./pulsar
+      cd .\pulsar
       choco pack
 
     - name: Install Current Version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
+        (
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+      
     - name: Build Current Version
       run: |
         cd ./pulsar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,13 @@ jobs:
         "$env:LOCALAPPDATA\Programs\Pulsar\resources\ppm\bin\" >> $env:GITHUB_PATH
 
     - name: Ensure Installation was successful
+      id: pulsar-version
       run: |
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
-        Where-Object {$_.Application -eq "Pulsar" } >> $env:GITHUB_STEP_SUMMARY
+        Where-Object {$_.Application -eq "Pulsar" } >> $GITHUB_OUTPUT
 
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
-        message: $env:GITHUB_STEP_SUMMARY
+        message: ${{ steps.pulsar-version.outputs }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
       run: |
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
-        Where-Object {$_.Application -eq "Pulsar" } >> $GITHUB_OUTPUT
+        Where-Object {$_.Application -eq "Pulsar" } >> $env:PulsarVersion
 
     - name: Write Comment
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          ${{ steps.pulsar-version.outputs }}
+          ${{ $PulsarVersion}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        version=$((
+        $version=(
         pulsar --version |
         ConvertFrom-String -PropertyNames Application,Delimiter,Version |
         Where-Object {$_.Application -eq "Pulsar" } |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,6 @@ jobs:
 
     - name: Can we set the Step Summary Successfully?
       run: echo "$((pulsar --version | Write-Host))" >> $env:GITHUB_STEP_SUMMARY
+
+    - name: What is possibly the value of GITHUB_STEP_SUMMARY?
+      run: echo $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         ConvertFrom-String -PropertyNames Application, Delimiter, Version |
         Where-Object { $PSItem.Application -eq "Pulsar" } |
         Select-Object -ExpandProperty version
-        Write-Host "pulsarVersion=$($version)" | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host "pulsarVersion='$($version)'" | Out-File -Append -FilePath $env:GITHUB_ENV
 
     - name: Just a check
       run: echo '${{ env.pulsarVersion }}'


### PR DESCRIPTION
This PR adds a GitHub Action to test installation Pulsar via the current generated repo's `pulsar.nuspec` file.

This GitHub Action should install Pulsar via the parameters of the `pulsar.nuspec` then run `pulsar --version` and output that as the step summary. Letting us see at a glance that one, everything executed without crashing, and two that the correct version is being output.