### PR TITLE
Add AutoPublishDraft GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Chocolatey Publish Pulsar
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  draft_publish:
+    if: contains(github.event.issue.labels.*.name, 'release')
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout Latest Code
+      uses: actions/checkout@v3
+
+    - name: Init New Version
+      run: python init.py ${{ github.event.issue.title }}
+
+    - name: Create Pull Request With Changes
+      run: gh pr create -B base_branch -H release --title '[${{ github.event.issue.title }}] Release' --body 'Automated PR'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR hopes to introduce a GitHub Action that can automatically draft a new release of the Pulsar chocolatey package.

Unfortunately, there's no real way to test the behavior of this PR without first merging and seeing if it'll work.

The way it's at least intended to function is that if an issue is created with a `release` label, and the title of the issue is something like `1.108.0` then a PR will be created with the changes needed for that version.

We would then hope our automated tests can confirm this works as expected.

The last step here, is a GitHub Action that can then go ahead and automatically publish this new release to Chocolatey. So that ideally the full workflow for a new Pulsar release would be:

1. Create Issue
2. Merge Draft PR
3. Trigger manual only action that publishes the new version to chocolatey