### PR TITLE
AutoPublish GitHub Action

### DIFF
--- a/.github/workflows/auto_publish.yml
+++ b/.github/workflows/auto_publish.yml
@@ -1,0 +1,23 @@
+name: Chocolatey Publish Pulsar Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout Latest Code
+      uses: actions/checkout@v3
+
+    - name: Build Package
+      run: |
+        cd ./pulsar
+        choco pack
+
+    - name: Publish New Version
+      run: |
+        $fileName = ( Get-ChildItem -Path . -Filter pulsar.*.nupkg )
+        Write-Host "Publishing $fileName to Chocolatey"
+        choco push $fileName --source https://push.chocolatey.org --apikey ${{ github.secrets.CHOCO_API_KEY }}

--- a/.github/workflows/draft_publish.yml
+++ b/.github/workflows/draft_publish.yml
@@ -1,4 +1,4 @@
-name: Chocolatey Publish Pulsar
+name: Chocolatey Draft Publish Pulsar
 
 on:
   issues:


### PR DESCRIPTION
Had to rename the previous draft publish GitHub Action for clarity, but this PR adds `auto_publish.yml` which allows publishing a new package to chocolatey once triggered manually.