### PR TITLE
CI: Simplify Pulsar version string parsing in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,5 @@ jobs:
     - name: Ensure Installation was successful
       id: pulsar-version
       run: |
-        (
-        pulsar --version |
-        ConvertFrom-String -PropertyNames Application,Delimiter,Version |
-        Where-Object {$_.Application -eq "Pulsar" } |
-        Select-Object -Property @{n='version'; e={ return "$($PSItem.Application) $($PSItem.Version)" }}
-        ).version >> $env:GITHUB_STEP_SUMMARY
+        $version = (pulsar --version | Out-String) -Split '\n' -Like 'Pulsar*' -Replace 'Pulsar' -Replace ':' -Replace '\s'
+        echo "Pulsar $version" >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Pursuant to a discussion on Discord: https://discord.com/channels/992103415163396136/1186519181592633434/1186570766343487528

I found a simpler, arguably more-readable way to parse the output of `pulsar --version` into just the Pulsar version (digits and dots).

After going back and forth a bit in Discord, this solution was requested to be posted as a PR.

I figured I'd go ahead and post it real quick before I forget and have to remind myself of the details tomorrow. So, here it is!

cc @confused-Techie 