### PR TITLE
Chore: Update nuspec copyright and docs url

### DIFF
--- a/pulsar/pulsar.nuspec
+++ b/pulsar/pulsar.nuspec
@@ -41,12 +41,12 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- There are a number of CDN Services that can be used for hosting the Icon for a package. More information can be found here: https://docs.chocolatey.org/en-us/create/create-packages#package-icon-guidelines -->
     <!-- Here is an example using Githack -->
     <iconUrl>https://cdn.statically.io/gh/pulsar-edit/pulsar-chocolatey/main/resources/icon.png</iconUrl>
-    <copyright>Copyright (c) 2022-2023 Pulsar-Edit</copyright>
+    <copyright>Copyright (c) 2022-2026 Pulsar-Edit</copyright>
     <!-- If there is a license Url available, it is required for the community feed -->
     <licenseUrl>https://github.com/pulsar-edit/pulsar/blob/master/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/pulsar-edit/pulsar</projectSourceUrl>
-    <docsUrl>https://pulsar-edit.dev/docs/</docsUrl>
+    <docsUrl>https://docs.pulsar-edit.dev</docsUrl>
     <!--<mailingListUrl></mailingListUrl>-->
     <bugTrackerUrl>https://github.com/pulsar-edit/pulsar/issues</bugTrackerUrl>
     <tags>pulsar editor text</tags>

--- a/pulsar/tools/LICENSE.txt
+++ b/pulsar/tools/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 Pulsar-Edit
+Copyright (c) 2022-2026 Pulsar-Edit
 Original work copyright (c) 2011-2022 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Bit late for the release as I only noticed this whilst looking at the Chocolatey website.

Updates the copyright field as well as the docs link (I think it still worked but best to use what we actually are on now).

We could probably update the licence field automatically by parsing the licence file if we wanted.